### PR TITLE
Desktop Background

### DIFF
--- a/game/gmtkgamejam2025/apps/commissions_app/commissions_app.gd
+++ b/game/gmtkgamejam2025/apps/commissions_app/commissions_app.gd
@@ -81,7 +81,11 @@ func on_download_pressed() -> void:
 
 func on_upload_pressed() -> void:
 	SoundManager.play_global_oneshot(&"ui_basic_click")
-	Desktop.instance.execute(&"file_explorer", {"upload": true})
+	var window: FileExplorerWindow = Desktop.instance.execute(&"file_explorer", {"upload": true})
+	window.upload_done.connect(_on_upload_finished)
+
+func _on_upload_finished(file_node: FileNode) -> void:
+	CommissionsManager.add_submission(file_node)
 
 func on_submit_pressed() -> void:
 	SoundManager.play_global_oneshot(&"ui_basic_click")

--- a/game/gmtkgamejam2025/apps/file_explorer_app/file_explorer_window/file_explorer_window.gd
+++ b/game/gmtkgamejam2025/apps/file_explorer_app/file_explorer_window/file_explorer_window.gd
@@ -1,12 +1,13 @@
 class_name FileExplorerWindow
 extends DesktopWindow
 
+signal upload_done(file_node: FileNode)
+
 ## ---
 ## FILE EXPLORER WINDOW
 ## ---
 
 @onready var file_explorer: FileExplorer = %FileExplorer
-
 
 func _ready() -> void:
 	super._ready()
@@ -22,12 +23,20 @@ func boot(args: Dictionary = {}) -> void:
 	else:
 		%WindowBar.set_window_title("File Explorer")
 	
+	if args.get("title_override") is String:
+		%WindowBar.set_window_title(args.get("title_override"))
+	
 	# if this is a upload file window, close this window when a file is selected
 	file_explorer.set_upload_mode(upload)
-	file_explorer.get_file_system_access().upload_done.connect(_on_close_pressed)
+	file_explorer.get_file_system_access().upload_done.connect(_on_upload_done)
 	
 	if args.has("folder_path"):
 		for folder_name in args.get("folder_path"):
 			file_explorer.file_system.change_directory(folder_name)
 	
 	SoundManager.play_global_oneshot(&"disk_read")
+
+## Upload selection made
+func _on_upload_done(file_node: FileNode) -> void:
+	upload_done.emit(file_node) ## Emit signal
+	_on_close_pressed() ## Close window

--- a/game/gmtkgamejam2025/apps/file_explorer_app/file_system_access.gd
+++ b/game/gmtkgamejam2025/apps/file_explorer_app/file_system_access.gd
@@ -13,7 +13,7 @@ var current_directory: Folder
 var directory_history: Array[Folder]
 var upload_mode: bool = false
 
-signal upload_done()
+signal upload_done(file_node: FileNode)
 
 func _ready() -> void:
 	current_directory = FileSystem.root
@@ -44,17 +44,18 @@ func go_back() -> bool:
 func get_current_contents() -> Array[FileNode]:
 	return current_directory.children
 
+## Interact with a file node
 func open_file(file_node: FileNode):
 	SoundManager.play_global_oneshot(&"ui_basic_click")
-	if file_node.is_folder():
+	
+	if file_node.is_folder(): ## Node is folder, navigate and terminate
 		change_directory(file_node.node_name)
-	else:
-		# This is where you would add logic to open a file.
-		# For now, we'll just print it.
+	else: ## Node is file, try and open...
 		print("Attempting to open file: ", file_node.node_name)
-		if upload_mode:
-			CommissionsManager.add_submission(file_node)
-			upload_done.emit()
+		
+		if upload_mode: ## We are doing uploading, so emit the upload
+			upload_done.emit(file_node)
 			return
+		
+		## We are not uploading, so open the file as expected
 		FileSystem.open_file(file_node)
-		# If you re-add the photoshop app, you would connect its 'open_file' method here.

--- a/game/gmtkgamejam2025/desktop/desktop.gd
+++ b/game/gmtkgamejam2025/desktop/desktop.gd
@@ -325,3 +325,19 @@ func _on_ending_fade_complete() -> void:
 	get_tree().change_scene_to_packed(scene)
 
 #endregion
+
+#region BACKGROUND ADJUSTMENT
+
+func prompt_change_background() -> void:
+	var window: FileExplorerWindow = Desktop.instance.execute(&"file_explorer", {"upload": true, "title_override": "Select a new desktop background"})
+	window.upload_done.connect(_on_bg_selected)
+
+func _on_bg_selected(file_node: FileNode) -> void:
+	var file: File = file_node
+	match file.file_type:
+		"image":
+			%DesktopBg.texture = file.get_file_resource().texture
+		_:
+			Desktop.instance.execute(&"error", {"text": "Invalid file type."})
+
+#endregion

--- a/game/gmtkgamejam2025/desktop/desktop.tscn
+++ b/game/gmtkgamejam2025/desktop/desktop.tscn
@@ -150,7 +150,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0, 0, 0, 1)
 
-[node name="DesktopBg" type="ColorRect" parent="CanvasLayer"]
+[node name="BaseDesktopBg" type="ColorRect" parent="CanvasLayer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -159,6 +159,14 @@ grow_vertical = 2
 mouse_filter = 2
 color = Color(0.435294, 0.54902, 0.501961, 1)
 metadata/_edit_use_anchors_ = true
+
+[node name="DesktopBg" type="TextureRect" parent="CanvasLayer"]
+unique_name_in_owner = true
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="DayLabel" type="RichTextLabel" parent="CanvasLayer"]
 unique_name_in_owner = true

--- a/game/gmtkgamejam2025/desktop/desktop.tscn
+++ b/game/gmtkgamejam2025/desktop/desktop.tscn
@@ -162,6 +162,7 @@ metadata/_edit_use_anchors_ = true
 
 [node name="DesktopBg" type="TextureRect" parent="CanvasLayer"]
 unique_name_in_owner = true
+modulate = Color(0.435294, 0.54902, 0.501961, 1)
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/game/gmtkgamejam2025/desktop/task_bar/settings/settings_button.gd
+++ b/game/gmtkgamejam2025/desktop/task_bar/settings/settings_button.gd
@@ -11,17 +11,26 @@ func _ready() -> void:
 	pivot_offset = size / 2.0
 	
 	pressed.connect(_on_pressed)
+	
+	GameStateManager.day_changed.connect(_on_day_changed)
+
+func _on_day_changed(new_day: int) -> void:
+	## Close the settings menu for the next day
+	if is_open:
+		toggle_open()
+		button_pressed = false
 
 func _on_pressed() -> void:
-	is_open = !is_open
-	
 	if not GameSettings.get_setting("reduced_motion", false, "graphics"):
 		TweenUtil.pop_delta(self, Vector2(0.2, 0.2), 0.3)
 	
 	SoundManager.play_global_oneshot(&"ui_basic_click")
 
-	
+	toggle_open()
 	#settings_panel.visible = !settings_panel.visible
+
+func toggle_open() -> void:
+	is_open = !is_open
 	
 	if is_open:
 		#settings_button_text.add_theme_color_override("default_color", Color.WHITE)

--- a/game/gmtkgamejam2025/desktop/task_bar/settings/settings_panel.gd
+++ b/game/gmtkgamejam2025/desktop/task_bar/settings/settings_panel.gd
@@ -57,5 +57,7 @@ func _on_motion_box_checked(is_toggled: bool) -> void:
 func _on_change_background_pressed() -> void:
 	## Launch background change prompt...
 	Desktop.instance.prompt_change_background()
+	
+	SoundManager.play_global_oneshot(&"ui_basic_click")
 
 #endregion

--- a/game/gmtkgamejam2025/desktop/task_bar/settings/settings_panel.gd
+++ b/game/gmtkgamejam2025/desktop/task_bar/settings/settings_panel.gd
@@ -4,6 +4,7 @@ extends PanelContainer
 @onready var music_slider: HSlider = %MusicSlider
 @onready var sound_slider: HSlider = %SoundSlider
 @onready var reduced_motion_box: CheckBox = %ReducedMotionBox
+@onready var change_bg_button: Button = %BgButton
 
 const MUSIC_BUS := &"Music"
 const SFX_BUS := &"SFX"
@@ -14,6 +15,7 @@ func _ready() -> void:
 	music_slider.value_changed.connect(_on_music_value_changed)
 	sound_slider.value_changed.connect(_on_sound_value_changed)
 	reduced_motion_box.toggled.connect(_on_motion_box_checked)
+	change_bg_button.pressed.connect(_on_change_background_pressed)
 	
 	GameSettings.load_from_config()
 	music_slider.value = GameSettings.get_setting("music_volume", 0.5, "audio")
@@ -49,3 +51,11 @@ func _on_motion_box_checked(is_toggled: bool) -> void:
 	
 	if ready_done:
 		SoundManager.play_global_oneshot(&"ui_basic_click")
+
+#region BACKGROUND ADJUSTMENT
+
+func _on_change_background_pressed() -> void:
+	## Launch background change prompt...
+	Desktop.instance.prompt_change_background()
+
+#endregion

--- a/game/gmtkgamejam2025/desktop/task_bar/settings_pivot.gd
+++ b/game/gmtkgamejam2025/desktop/task_bar/settings_pivot.gd
@@ -3,7 +3,7 @@ extends Control
 @onready var pos := position
 
 func _ready() -> void:
-	position = pos + Vector2.DOWN * 256.0
+	position = pos + Vector2.DOWN * 280.0
 
 func open() -> void:
 	visible = true
@@ -15,7 +15,7 @@ func open() -> void:
 
 func close() -> void:
 	if GameSettings.get_setting("reduced_motion", false, "graphics"):
-		position = pos + Vector2.DOWN * 256.0
+		position = pos + Vector2.DOWN * 280.0
 		return
-	TweenUtil.whoosh(self, pos + Vector2.DOWN * 256.0, 0.3)
+	TweenUtil.whoosh(self, pos + Vector2.DOWN * 280.0, 0.3)
 	#TweenUtil.pop_delta(self, Vector2(-0.3, 0), 0.4)

--- a/game/gmtkgamejam2025/desktop/task_bar/task_bar.gd
+++ b/game/gmtkgamejam2025/desktop/task_bar/task_bar.gd
@@ -40,6 +40,8 @@ func add_task(window: DesktopWindow) -> void:
 	
 	shortcut.button_pressed = true
 	set_active(shortcut)
+	if not GameSettings.get_setting("reduced_motion", false, "graphics"):
+		TweenUtil.pop_delta(shortcut, Vector2(0.2, 0.2), 0.5)
 	
 	_arrange_icons()
 
@@ -58,6 +60,8 @@ func remove_task(window: DesktopWindow) -> void:
 	if Desktop.instance.has_active_window():
 		shortcut = window_dict.get(Desktop.instance.get_active_window())
 		set_active(shortcut)
+		if not GameSettings.get_setting("reduced_motion", false, "graphics"):
+			TweenUtil.pop_delta(shortcut, Vector2(0.2, 0.2), 0.5)
 	
 	_arrange_icons()
 
@@ -77,7 +81,7 @@ func _arrange_icons() -> void:
 		var offset = so_far
 		if not GameSettings.get_setting("reduced_motion", false, "graphics"):
 			TweenUtil.whoosh(icon, Vector2(offset, 0))
-			TweenUtil.pop_delta(icon, Vector2(0.2, 0.2), 0.5)
+			#TweenUtil.pop_delta(icon, Vector2(0.2, 0.2), 0.5)
 		else:
 			icon.position = Vector2(offset, 0)
 		

--- a/game/gmtkgamejam2025/desktop/task_bar/task_bar.tscn
+++ b/game/gmtkgamejam2025/desktop/task_bar/task_bar.tscn
@@ -311,7 +311,18 @@ theme_override_colors/default_color = Color(0, 0, 0, 1)
 text = "Reduced Motion"
 
 [node name="Control3" type="Control" parent="SettingsPivot/SettingsPanel/HBoxContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 20)
+custom_minimum_size = Vector2(0, 5)
+layout_mode = 2
+
+[node name="BgButton" type="Button" parent="SettingsPivot/SettingsPanel/HBoxContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+mouse_default_cursor_shape = 2
+theme = ExtResource("5_e36ol")
+text = "Change Background"
+
+[node name="Control4" type="Control" parent="SettingsPivot/SettingsPanel/HBoxContainer/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 
 [node name="TaskBarTexture" type="TextureRect" parent="."]


### PR DESCRIPTION
Please test and ensure no bug regressions

- Refactored the file system window to send a signal with the selected file upon selection during upload mode. Moved the commissions file node upload to the commissions app and not the file system logic.
- Added a button to the settings to open a change background prompt. Selecting any image will load that as your background, with a green tint for accessibility. Background does not currently persist between separate game sessions (unlike other settings)
- Tweaked a few minor things relating to task bar shortcut popping and made settings auto-close before next day